### PR TITLE
Always set the BD bit on a trap in a branch-delay slot (even if not t…

### DIFF
--- a/cheri/cheri_insts.sail
+++ b/cheri/cheri_insts.sail
@@ -951,6 +951,8 @@ function clause execute (CBX(cb, imm, notset)) =
     let offset : bits(64) = (sign_extend(imm @ 0b00) + 4) in
     execute_branch(PC + offset);
   }
+  else
+    execute_branch(PC + 4);  /* Next instruction should still cause the BD flag to be set on trap */
 }
 
 union clause ast = CBZ : (regno, bits(16), bool)
@@ -962,6 +964,8 @@ function clause execute (CBZ(cb, imm, notzero)) =
     let offset : bits(64) = (sign_extend(imm @ 0b00) + 4) in
     execute_branch(PC + offset);
   }
+  else
+    execute_branch(PC + 4);  /* Next instruction should still cause the BD flag to be set on trap */
 }
 
 union clause ast = CJALR : (regno, regno, bool)

--- a/mips/mips_insts.sail
+++ b/mips/mips_insts.sail
@@ -940,7 +940,9 @@ function clause execute (BEQ(rs, rd, imm, ne, likely)) =
     else
       {
         if (likely) then
-          nextPC = PC + 8; /* skip branch delay */
+          nextPC = PC + 8 /* skip branch delay */
+        else
+          execute_branch(PC + 4);  /* Next instruction should still cause the BD flag to be set on trap */
       }
   }
 
@@ -996,6 +998,10 @@ function clause execute (BCMPZ(rs, imm, cmp, link, likely)) =
     else if (likely) then
       {
         nextPC = PC + 8  /* skip branch delay */
+      }
+    else
+      {
+        execute_branch(PC + 4);  /* Next instruction should still cause the BD flag to be set on trap */
       };
     if (link) then
       wGPR(0b11111) = linkVal


### PR DESCRIPTION
…aken)

See table 6.11 of https://s3-eu-west-1.amazonaws.com/downloads-mips/documents/MD00091-2B-MIPS64PRA-AFP-06.03.pdf
The only exception is if EXL is set (see comments in the spec):
/* If StatusEXL is 1, all exceptions go through the general exception vector */
/* and neither EPC nor CauseBD nor SRSCtl are modified */