### PR TITLE
Changes for forwards compability with future versions of Sail

### DIFF
--- a/cheri/cheri_insts.sail
+++ b/cheri/cheri_insts.sail
@@ -311,9 +311,9 @@ function clause execute(CPtrCmp(rd, cb, ct, op)) =
   checkCP2usable();
   let cb_val = readCapReg(cb);
   let ct_val = readCapReg(ct);
-  equal  = false;
-  ltu    = false;
-  lts    = false;
+  equal : bool = false;
+  ltu   : bool = false;
+  lts   : bool = false;
   if cb_val.tag != ct_val.tag then
     {
       if not (cb_val.tag) then

--- a/cheri/cheri_prelude_128.sail
+++ b/cheri/cheri_prelude_128.sail
@@ -380,9 +380,9 @@ function setCapBounds(cap, base, top) : (Capability, bits(64), bits(65)) -> (boo
   /* The non-ie e == 0 case is easy. It is exact so just extract relevant bits. */
   Bbits = truncate(base, 14);
   Tbits = truncate(top, 14);
-  lostSignificantTop = false;
-  lostSignificantBase = false;
-  incE = false;
+  lostSignificantTop  : bool = false;
+  lostSignificantBase : bool = false;
+  incE : bool = false;
   
   if ie then {
     /* the internal exponent case is trickier */

--- a/mips/main.sail
+++ b/mips/main.sail
@@ -25,7 +25,7 @@ function fetch_and_execute () = {
     prerr("PC: ");
     prerr(BitStr(PC));
   };
-  loop_again = true;
+  loop_again : bool = true;
   try {
     let pc_pa = TranslatePC(PC);
     /*print_bits("pa: ", pc_pa);*/

--- a/mips/prelude.sail
+++ b/mips/prelude.sail
@@ -153,6 +153,8 @@ union exception = {
   Error_internal_error : unit
 }
 
+$ifndef FEATURE_IMPLICITS
+
 /* These functions make the first parameter to builtin extension
 functions implicit from length of returned vector.  */
 
@@ -187,6 +189,35 @@ val ones_implicit : forall 'n, 'n >= 0 . unit -> bits('n)
 function ones_implicit () = ones_n ('n)
 
 overload ones = {ones_implicit, ones_n}
+
+$else
+
+/* These functions make the first parameter to builtin extension
+functions implicit from length of returned vector.  */
+
+val mips_sign_extend : forall 'n 'm, 'm >= 'n. (implicit('m), bits('n)) -> bits('m)
+val mips_zero_extend : forall 'n 'm, 'm >= 'n. (implicit('m), bits('n)) -> bits('m)
+
+function mips_sign_extend(m, v) = sail_sign_extend(v, m)
+function mips_zero_extend(m, v) = sail_zero_extend(v, m)
+
+/* Because sail already has builtins with these names we use overload to rename above. */
+overload sign_extend = {mips_sign_extend}
+overload zero_extend = {mips_zero_extend}
+
+val zeros_implicit : forall 'n, 'n >= 0. (implicit('n), unit) -> bits('n)
+function zeros_implicit(n, _) = sail_zeros(n)
+overload zeros = {zeros_implicit, sail_zeros}
+
+val ones_n : forall 'n, 'n >= 0. int('n) -> bits('n)
+function ones_n n = replicate_bits(0b1, n)
+
+val ones_implicit : forall 'n, 'n >= 0. (implicit('n), unit) -> bits('n)
+function ones_implicit(n, _) = ones_n(n)
+
+overload ones = {ones_implicit, ones_n}
+
+$endif
 
 infix 4 <_s
 infix 4 >=_s
@@ -243,7 +274,12 @@ THIS`(l, v)` converts an integer, `v`,  to a bit vector of length `l`. If `v` is
 val to_bits : forall 'l, 'l >= 0 .(atom('l), int) -> bits('l)
 function to_bits (l, n) = get_slice_int(l, n, 0)
 
-val mask : forall 'm 'n , 'm >= 'n > 0 . bits('m) -> bits('n)
-function mask bs = bs['n - 1 .. 0]
+$ifndef FEATURE_IMPLICITS
+val mask : forall 'm 'n, 'm >= 'n > 0. bits('m) -> bits('n)
+function mask(bs) = bs['n - 1 .. 0]
+$else
+val mask : forall 'm 'n, 'm >= 'n > 0. (implicit('n), bits('m)) -> bits('n)
+function mask(n, bs) = bs[n - 1 .. 0]
+$endif
 
 val "get_time_ns" : unit -> int


### PR DESCRIPTION
Future Sail versions require slightly more type annotations on mutable boolean variables.

There is new syntax for implicit arguments which removes much of the slowness and complexity of the previous approach, by making things more explicit in the valspecs. For now we can have the old and new syntax available using a $ifndef old $else new $endif structure in the prelude.