### PR TITLE
Adapt to changes in Sail's Lem shallow embedding

### DIFF
--- a/cheri/Holmakefile
+++ b/cheri/Holmakefile
@@ -1,6 +1,4 @@
-LEMDIR=../../lem/hol-lib
-
-INCLUDES = $(LEMDIR) $(SAIL_LIB_DIR)/hol
+INCLUDES = $(LEM_DIR)/hol-lib $(SAIL_LIB_DIR)/hol
 
 all: cheriTheory.uo
 .PHONY: all

--- a/cheri/cheri_insts.sail
+++ b/cheri/cheri_insts.sail
@@ -1011,17 +1011,17 @@ function clause execute (CLoadTags(rd, cb)) =
       SignalExceptionBadAddr(AdEL, vAddr64)
     else
       {
-        let pAddr  = TLBTranslate(vAddr64, LoadData);
-        let tag0   = MEMr_tag(pAddr + 0*cap_size);
-        let tag1   = MEMr_tag(pAddr + 1*cap_size);
-        let tag2   = MEMr_tag(pAddr + 2*cap_size);
-        let tag3   = MEMr_tag(pAddr + 3*cap_size);
-        let tag4   = MEMr_tag(pAddr + 4*cap_size);
-        let tag5   = MEMr_tag(pAddr + 5*cap_size);
-        let tag6   = MEMr_tag(pAddr + 6*cap_size);
-        let tag7   = MEMr_tag(pAddr + 7*cap_size);
-        wGPR(rd)   = zero_extend (tag7 @ tag6 @ tag5 @ tag4
-                                @ tag3 @ tag2 @ tag1 @ tag0);
+        let pAddr     = TLBTranslate(vAddr64, LoadData);
+        let (tag0, _) = MEMr_tagged(pAddr + 0*cap_size, cap_size);
+        let (tag1, _) = MEMr_tagged(pAddr + 1*cap_size, cap_size);
+        let (tag2, _) = MEMr_tagged(pAddr + 2*cap_size, cap_size);
+        let (tag3, _) = MEMr_tagged(pAddr + 3*cap_size, cap_size);
+        let (tag4, _) = MEMr_tagged(pAddr + 4*cap_size, cap_size);
+        let (tag5, _) = MEMr_tagged(pAddr + 5*cap_size, cap_size);
+        let (tag6, _) = MEMr_tagged(pAddr + 6*cap_size, cap_size);
+        let (tag7, _) = MEMr_tagged(pAddr + 7*cap_size, cap_size);
+        wGPR(rd)      = zero_extend (tag7 @ tag6 @ tag5 @ tag4
+                                   @ tag3 @ tag2 @ tag1 @ tag0);
       }
   }
 }
@@ -1138,7 +1138,7 @@ function clause execute (CSC(cs, cb, rt, offset)) =
       if cs_val.tag & noStoreCap then
         raise_c2_exception(CapEx_TLBNoStoreCap, cs)
       else 
-        MEMw_tagged(pAddr, cs_val.tag, capToMemBits(cs_val));
+        MEMw_tagged(pAddr, cap_size, cs_val.tag, capToMemBits(cs_val));
     }
   }
 }
@@ -1177,7 +1177,7 @@ function clause execute (CSCC(cs, cb, rd)) =
       else
       {
         let success = if (CP0LLBit[0]) then
-            MEMw_tagged_conditional(pAddr, cs_val.tag, capToMemBits(cs_val))
+            MEMw_tagged_conditional(pAddr, cap_size, cs_val.tag, capToMemBits(cs_val))
           else
             false;
         wGPR(rd) = zero_extend(success);
@@ -1211,7 +1211,7 @@ function clause execute (CLC(cd, cb, rt, offset)) =
     else
     {
       let (pAddr, suppressTag) = TLBTranslateC(vAddr64, LoadData);
-      let (tag, mem) = MEMr_tagged(pAddr);
+      let (tag, mem) = MEMr_tagged(pAddr, cap_size);
       let cap = memBitsToCapability(tag & cb_val.permit_load_cap & not (suppressTag), mem);
       writeCapReg(cd, cap);
     }
@@ -1243,7 +1243,7 @@ function clause execute (CLCBI(cd, cb, offset)) =
     else
     {
       let (pAddr, suppressTag) = TLBTranslateC(vAddr64, LoadData);
-      let (tag, mem) = MEMr_tagged(pAddr);
+      let (tag, mem) = MEMr_tagged(pAddr, cap_size);
       let cap = memBitsToCapability(tag & cb_val.permit_load_cap & not (suppressTag), mem);
       writeCapReg(cd, cap);
     }
@@ -1274,7 +1274,7 @@ function clause execute (CLLC(cd, cb)) =
     else
     {
       let (pAddr, suppressTag) = TLBTranslateC(vAddr64, LoadData);
-      let (tag, mem) : (bool, CapBits) = MEMr_tagged_reserve(pAddr);
+      let (tag, mem) : (bool, CapBits) = MEMr_tagged_reserve(pAddr, cap_size);
       let cap = memBitsToCapability(tag & cb_val.permit_load_cap & not (suppressTag), mem);
       writeCapReg(cd, cap);
       CP0LLBit  = 0b1;

--- a/cheri/cheri_insts.sail
+++ b/cheri/cheri_insts.sail
@@ -318,9 +318,9 @@ function clause execute(CPtrCmp(rd, cb, ct, op)) =
   checkCP2usable();
   let cb_val = readCapReg(cb);
   let ct_val = readCapReg(ct);
-  equal  = false;
-  ltu    = false;
-  lts    = false;
+  equal : bool = false;
+  ltu   : bool = false;
+  lts   : bool = false;
   if cb_val.tag != ct_val.tag then
     {
       if not (cb_val.tag) then

--- a/cheri/cheri_prelude_common.sail
+++ b/cheri/cheri_prelude_common.sail
@@ -341,76 +341,68 @@ function raise_c2_exception_noreg(capEx) =
 val pcc_access_system_regs : unit -> bool effect {rreg}
 function pcc_access_system_regs () = PCC.access_system_regs
 
+let cap_addr_mask = to_bits(64, pow2(64) - cap_size)
+
 /*!
 reads the tag associated with the given physical address.
  */
-val MEMr_tag = "read_tag_bool"  : bits(64) -> bool effect { rmemt }
-val MEMw_tag = "write_tag_bool" : (bits(64) , bool) -> unit effect { wmvt }
+val "read_tag_bool"  : bits(64) -> bool effect { rmemt }
+val "write_tag_bool" : (bits(64) , bool) -> unit effect { wmvt }
 
 /*!
-reads `cap_size` bytes from the given physical address in memory and the associated tag value. The address should be capability-aligned.
+reads `size` bytes from the given physical address in memory and the associated tag value.
  */
-val MEMr_tagged : bits(64) -> (bool, bits('cap_size * 8)) effect { escape, rmem, rmemt }
-function MEMr_tagged (addr) =
+val MEMr_tagged = {lem: "MEMr_tagged"} : forall 'size, 'size > 0. (bits(64), atom('size)) -> (bool, bits('size * 8)) effect { rmem, rmemt }
+function MEMr_tagged (addr, size) =
 {
-  /* assumes addr is cap. aligned */
-  assert(unsigned(addr) % cap_size == 0);
-  let tag  = MEMr_tag(addr) in
-  let data = MEMr(addr, cap_size) in
+  let tag  = read_tag_bool(addr & cap_addr_mask) in
+  let data = MEMr(addr, size) in
   (tag, reverse_endianness(data))
 }
 
 /*!
 is as [MEMr_tagged] except that the load is marked as part of a load linked / store conditional.
  */
-val MEMr_tagged_reserve : bits(64) -> (bool, bits('cap_size * 8)) effect { escape, rmem, rmemt }
-function MEMr_tagged_reserve (addr) =
+val MEMr_tagged_reserve = {lem: "MEMr_tagged_reserve"} : forall 'size, 'size > 0. (bits(64), atom('size)) -> (bool, bits('size * 8)) effect { rmem, rmemt }
+function MEMr_tagged_reserve (addr, size) =
 {
-  /* assumes addr is cap. aligned */
-  assert(unsigned(addr) % cap_size == 0);
-  let tag = MEMr_tag(addr) in
-  let data = MEMr_reserve(addr, cap_size) in
+  let tag = read_tag_bool(addr & cap_addr_mask) in
+  let data = MEMr_reserve(addr, size) in
   (tag, reverse_endianness(data))
 }
 
 /*!
-THIS`(addr, t, value)` writes `cap_size` bytes, `value`, to physical address, `addr`, with associated tag value, `t`.
+THIS`(addr, size, t, value)` writes `size` bytes, `value`, to physical address, `addr`, with associated tag value, `t`.
  */
-val MEMw_tagged : (bits(64), bool, bits('cap_size * 8)) -> unit effect { escape, eamem, wmv, wmvt }
-function MEMw_tagged(addr, tag, data) =
+val MEMw_tagged = {lem: "MEMw_tagged"} : forall 'size, 'size > 0. (bits(64), atom('size), bool, bits('size * 8)) -> unit effect { eamem, wmv, wmvt }
+function MEMw_tagged(addr, size, tag, data) =
 {
-  /* assumes addr is cap. aligned */
-  assert(unsigned(addr) % cap_size == 0);
-  MEMea(addr, cap_size);
-  MEMval(addr, cap_size, reverse_endianness(data));
-  MEMw_tag(addr, tag);
+  MEMea(addr, size);
+  MEMval(addr, size, reverse_endianness(data));
+  write_tag_bool(addr & cap_addr_mask, tag);
 }
 
 /*!
-THIS`(addr, t, value)` writes `cap_size` bytes, `value`, to physical address, `addr`, with associated tag value, `t` and returns store conditional success or failure.
+THIS`(addr, size, t, value)` writes `size` bytes, `value`, to physical address, `addr`, with associated tag value, `t` and returns store conditional success or failure.
  */
-val MEMw_tagged_conditional : (bits(64), bool, bits('cap_size * 8)) -> bool effect { escape, eamem, wmv, wmvt }
-function MEMw_tagged_conditional(addr, tag, data) =
+val MEMw_tagged_conditional = {lem: "MEMw_tagged_conditional"}: forall 'size, 'size > 0. (bits(64), atom('size), bool, bits('size * 8)) -> bool effect { eamem, wmv, wmvt }
+function MEMw_tagged_conditional(addr, size, tag, data) =
 {
-  /* assumes addr is cap. aligned */
-  assert(unsigned(addr) % cap_size == 0);
-  MEMea_conditional(addr, cap_size);
-  success = MEMval_conditional(addr, cap_size, reverse_endianness(data));
+  MEMea_conditional(addr, size);
+  success = MEMval_conditional(addr, size, reverse_endianness(data));
   if success then
-     MEMw_tag(addr, tag);
+     write_tag_bool(addr & cap_addr_mask, tag);
   success;
 }
-
-let cap_addr_mask = to_bits(64, pow2(64) - cap_size)
 
 /*!
 THIS`(addr, size, value)` writes `size` bytes of `value` to physical address `addr`.
  */
 val MEMw_wrapper : forall 'n, 'n >= 1. (bits(64), atom('n), bits(8 * 'n)) -> unit effect {escape, wmv, wmvt, wreg, eamem}
 function MEMw_wrapper(addr, size, data) =
-  let ledata = reverse_endianness(data) in
   if (addr == 0x000000007f000000) then
   {
+    let ledata   = reverse_endianness(data) in
     UART_WDATA   = ledata[7..0];
     UART_WRITTEN = 0b1;
   }
@@ -418,10 +410,8 @@ function MEMw_wrapper(addr, size, data) =
   {
     /* require that writes don't cross capability boundaries (should be true due to mips alignment requirements) */  
     assert((addr & cap_addr_mask) == ((addr + to_bits(64, size - 1)) & cap_addr_mask));
-    MEMea(addr, size);
-    MEMval(addr, size, ledata);
-    /* On cheri non-capability writes must clear the corresponding tag*/
-    MEMw_tag(addr & cap_addr_mask, false);
+    /* On cheri non-capability writes must clear the corresponding tag */
+    MEMw_tagged(addr, size, false, data);
   }
 
 /*!
@@ -432,12 +422,8 @@ function MEMw_conditional_wrapper(addr, size, data) =
   {
     /* require that writes don't cross capability boundaries (should be true due to mips alignment requirements) */
     assert((addr & cap_addr_mask) == ((addr + to_bits(64, size - 1)) & cap_addr_mask));
-    MEMea_conditional(addr, size);
-    success = MEMval_conditional(addr,size,reverse_endianness(data));
-    if success then
-       /* On cheri non-capability writes must clear the corresponding tag */
-       MEMw_tag(addr & cap_addr_mask, false);
-    success;
+    /* On cheri non-capability writes must clear the corresponding tag */
+    MEMw_tagged_conditional(addr, size, false, data)
   }
 
 val checkDDCPerms : (Capability, MemAccessType) -> unit effect {escape, rreg, wreg}

--- a/mips/main.sail
+++ b/mips/main.sail
@@ -25,7 +25,7 @@ function fetch_and_execute () = {
     prerr("PC: ");
     prerr(BitStr(PC));
   };
-  loop_again = true;
+  loop_again : bool = true;
   try {
     let pc_pa = TranslatePC(PC);
     /*print_bits("pa: ", pc_pa);*/

--- a/mips/mips_extras.lem
+++ b/mips/mips_extras.lem
@@ -6,30 +6,22 @@ open import Sail2_operators
 open import Sail2_prompt_monad
 open import Sail2_prompt
 
-val MEMr             : forall 'regval 'a 'b 'e. Bitvector 'a, Bitvector 'b => 'a -> integer -> monad 'regval 'b 'e
-val MEMr_reserve     : forall 'regval 'a 'b 'e. Bitvector 'a, Bitvector 'b => 'a -> integer -> monad 'regval 'b 'e
-val MEMr_tag         : forall 'regval 'a 'b 'e. Bitvector 'a, Bitvector 'b => 'a -> integer -> monad 'regval (bool * 'b) 'e
-val MEMr_tag_reserve : forall 'regval 'a 'b 'e. Bitvector 'a, Bitvector 'b => 'a -> integer -> monad 'regval (bool * 'b) 'e
+val MEMr                : forall 'regval 'a 'b 'e. Bitvector 'a, Bitvector 'b => 'a -> integer -> monad 'regval 'b 'e
+val MEMr_reserve        : forall 'regval 'a 'b 'e. Bitvector 'a, Bitvector 'b => 'a -> integer -> monad 'regval 'b 'e
+val MEMr_tagged         : forall 'regval 'a 'b 'e. Bitvector 'a, Bitvector 'b => 'a -> integer -> monad 'regval (bool * 'b) 'e
+val MEMr_tagged_reserve : forall 'regval 'a 'b 'e. Bitvector 'a, Bitvector 'b => 'a -> integer -> monad 'regval (bool * 'b) 'e
 
 let MEMr addr size             = read_mem Read_plain addr size
 let MEMr_reserve addr size     = read_mem Read_reserve addr size
 
-val read_tag_bool : forall 'regval 'a 'e. Bitvector 'a => 'a -> monad 'regval bool 'e
-let read_tag_bool addr =
-  read_tag addr >>= fun t ->
-  maybe_fail "read_tag_bool" (bool_of_bitU t)
-
-val write_tag_bool : forall 'regval 'a 'e. Bitvector 'a => 'a -> bool -> monad 'regval unit 'e
-let write_tag_bool addr t = write_tag addr (bitU_of_bool t) >>= fun _ -> return ()
-
-let MEMr_tag addr size =
-  read_mem Read_plain addr size >>= fun v ->
-  read_tag_bool addr >>= fun t ->
+let MEMr_tagged addr size =
+  read_memt Read_plain addr size >>= fun (v, t) ->
+  maybe_fail "bool_of_bitU" (bool_of_bitU t) >>= fun t ->
   return (t, v)
 
-let MEMr_tag_reserve addr size =
-  read_mem Read_plain addr size >>= fun v ->
-  read_tag_bool addr >>= fun t ->
+let MEMr_tagged_reserve addr size =
+  read_memt Read_plain addr size >>= fun (v, t) ->
+  maybe_fail "bool_of_bitU" (bool_of_bitU t) >>= fun t ->
   return (t, v)
 
 
@@ -41,19 +33,20 @@ val MEMea_tag_conditional : forall 'regval 'a 'e. Bitvector 'a => 'a -> integer 
 let MEMea addr size                 = write_mem_ea Write_plain addr size
 let MEMea_conditional addr size     = write_mem_ea Write_conditional addr size
 
-let MEMea_tag addr size             = write_mem_ea Write_plain addr size
-let MEMea_tag_conditional addr size = write_mem_ea Write_conditional addr size
+val MEMval                    : forall 'regval 'a 'b 'e. Bitvector 'a, Bitvector 'b => 'a -> integer -> 'b -> monad 'regval unit 'e
+val MEMval_conditional        : forall 'regval 'a 'b 'e. Bitvector 'a, Bitvector 'b => 'a -> integer -> 'b -> monad 'regval bool 'e
+val MEMval_tagged             : forall 'regval 'a 'b 'e. Bitvector 'a, Bitvector 'b => 'a -> integer -> bool -> 'b -> monad 'regval unit 'e
+val MEMval_tagged_conditional : forall 'regval 'a 'b 'e. Bitvector 'a, Bitvector 'b => 'a -> integer -> bool -> 'b -> monad 'regval bool 'e
 
+let MEMval addr size v                      = write_mem Write_plain addr size v >>= fun _ -> return ()
+let MEMval_conditional addr size v          = write_mem Write_conditional addr size v
+let MEMval_tagged addr size t v             = write_memt Write_plain addr size v (bitU_of_bool t) >>= fun _ -> return ()
+let MEMval_tagged_conditional addr size t v = write_memt Write_conditional addr size v (bitU_of_bool t)
 
-val MEMval                 : forall 'regval 'a 'b 'e. Bitvector 'a, Bitvector 'b => 'a -> integer -> 'b -> monad 'regval unit 'e
-val MEMval_conditional     : forall 'regval 'a 'b 'e. Bitvector 'a, Bitvector 'b => 'a -> integer -> 'b -> monad 'regval bool 'e
-val MEMval_tag             : forall 'regval 'a 'b 'e. Bitvector 'a, Bitvector 'b => 'a -> integer -> bool -> 'b -> monad 'regval unit 'e
-val MEMval_tag_conditional : forall 'regval 'a 'b 'e. Bitvector 'a, Bitvector 'b => 'a -> integer -> bool -> 'b -> monad 'regval bool 'e
-
-let MEMval _ size v                      = write_mem_val v >>= fun _ -> return ()
-let MEMval_conditional _ size v          = write_mem_val v >>= fun b -> return (if b then true else false)
-let MEMval_tag addr size t v             = write_mem_val v >>= fun _ -> write_tag_bool addr t >>= fun _ -> return ()
-let MEMval_tag_conditional addr size t v = write_mem_val v >>= fun b -> write_tag_bool addr t >>= fun _ -> return (if b then true else false)
+let MEMw addr size t v                    = MEMea addr size             >> MEMval addr size v
+let MEMw_conditional addr size t v        = MEMea_conditional addr size >> MEMval_conditional addr size v
+let MEMw_tagged addr size t v             = MEMea addr size             >> MEMval_tagged addr size t v
+let MEMw_tagged_conditional addr size t v = MEMea_conditional addr size >> MEMval_tagged_conditional addr size t v
 
 val MEM_sync  : forall 'regval 'e. unit -> monad 'regval unit 'e
 


### PR DESCRIPTION
There is no interface any more for reading/writing a tag without also reading/writing a memory value;  the latter also requires the size of the read/write as a parameter.